### PR TITLE
Add WSL/2 notes to Windows installation section

### DIFF
--- a/_includes/markdown/Installation.md
+++ b/_includes/markdown/Installation.md
@@ -18,6 +18,16 @@ if you'd like to run the command without sudo. Alternatively, just run the insta
 [Docker Desktop](https://docs.docker.com/docker-for-windows/install/) is available for download from the [Docker website](https://docs.docker.com/docker-for-windows/install/) and will
 install docker-compose automatically. NodeJS and npm can be installed from the [NodeJS website](https://nodejs.org). You may also need [Python](https://www.python.org/downloads/windows/) 3.7+ and [Visual Studio](https://visualstudio.microsoft.com/downloads/) 2015 or newer with the [“Desktop development with C++” workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-160).
 
+It is recommended that you use the [WSL/2 backend for Docker)(https://docs.docker.com/docker-for-windows/wsl/). You should use ([nvm](https://github.com/creationix/nvm) to install Node inside of your default Linux distro. Once you have, you can install WP Local Docker, from inside of Linux, following the [installation instructions](#Installation).
+
+It is helpful to share git credentials between Windows and WSL/2. To do so, run the following, from inside of your default Linux, making sure to change `USER-NAME` to your Windows username:
+
+```bash
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager.exe"
+cd ~/.ssh
+cp /mnt/c/Users/USER-NAME/.ssh/id_rsa* .
+```
+
 #### Linux
 Docker has platform specific installation instructions available for linux on their [documentation site](https://docs.docker.com/install/#supported-platforms).
 Once docker is installed, you will need to [manually install docker compose](https://docs.docker.com/compose/install/).


### PR DESCRIPTION

### Description of the Change

Fixes #38 by improving Windows install notes. Adds a recommendation to use WSL/2 backend, and to use nvm to manage Node in WSL/2 which was recommended to me in 10up Slack. Also includes a note about using  Window's git credentials manager from Linux.

### Alternate Designs


### Benefits

I spent a many hours figuring this all out and getting help from others. I am hoping to prevent others from having to do the same digging.

### Possible Drawbacks

I worry about adding to much information, which could go stale with changes to the software.

This is already verging on WSL/2 and Linux tutorial.
### Verification Process

These are the steps I took to get WP Local Docker working for me, on 10up projects.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

#38 

### Changelog Entry

- Added additional notes to Windows installation documenation.
