### PR TITLE
Add PHPStorm instructions for XDebug

### DIFF
--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -37,3 +37,35 @@ Make sure your IDE is listening for PHP debug connections and set up a path mapp
         }
 ]
 ```
+
+### PHPStorm
+
+Helpful documentation links:
+- https://www.jetbrains.com/help/phpstorm/configuring-xdebug.html
+- https://www.jetbrains.com/help/phpstorm/servers.html
+
+*NOTE: the above documents have a lot of information that isn't relevant to our specific setup; use them mostly as reference*
+
+1. Ensure Xdebug is enabled for the environment using the `ENABLE_XDEBUG` environment variable.
+2. Ensure the following configuration is set in `site-name-test/config/php-fpm/docker-php-ext-xdebug.ini`:
+```
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_host = host.docker.internal
+```
+3. Download and install the Chrome XDebug Helper extension (or XDebug extension for whichever browser you use): https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc
+- *NOTE: If you have set `xdebug.remote_autostart = 1` in `docker-php-ext-xdebug.ini`, you will not need this extension
+4. When visiting the site in your browser, use the extension to set your mode to "Debug", as this will set a specific Cookie value, enabling a connection from XDebug
+5. In PHPStorm, open Settings -> Languages & Frameworks -> PHP -> Servers and click the "+" (Add New Server) button to add a new server with the following settings:
+- `Name` should match the setting within your `docker-compose.yml` file from the following line: `PHP_IDE_CONFIG: serverName=site-name-test`. Note the `serverName=site-name-test` value. `Name` should match the value of `serverName` **exactly**.
+- `Host` should match the host you access the site in the browser with, excluding `.test`. E.G. `site-name.test` becomes `site-name` for the `Host` field.
+- `Port` can leave as default `80`.
+- `Use path mappings` should be enabled, and you will need to setup 1 mapping; your local `site-name-test/wordpress` folder should be mapped to `/var/www/html`
+6. In PHPStorm, open Settings -> Languages & Frameworks -> PHP -> Debug and ensure the following settings are configured:
+- `Can accept external connections` should be enabled
+- `Force break at first line when no path mapping specified` can be enabled, though it is more convenient to disable it (once you've ensured your path mapping works properly at least once)
+- `Force break at first line when a script is outside the project` can be enabled, though it is more convenient to disable it
+7. In PHPStorm, run the "Start Listening for PHP Debug Connections" tool ![Markup on 2021-03-18 at 09:26:34](https://user-images.githubusercontent.com/4182573/111633599-0f050f00-87cc-11eb-8449-6a4131f06043.png)
+8. Within your project, set a breakpoint in a PHP file where you know will be executed
+9. Reload the page and you should immediately see the Debug tool window open in PHPStorm, breaking on the line you have added the breakpoint to
+


### PR DESCRIPTION
### Description of the Change

Add instructions for using XDebug with PHPStorm

### Benefits

Users using PHPStorm will now have instructions to use XDebug with our setup


### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

```
### Added
- PHPStorm instructions for XDebug
```