### PR TITLE
Add configuration and recreation instructions

### DIFF
--- a/_includes/markdown/Environments.md
+++ b/_includes/markdown/Environments.md
@@ -40,11 +40,40 @@ A special hostname `all` is available that will stop all running environments as
 
 A special hostname `all` is available that will start all environments as well as the global services.
 
+## Configure an Environment
+
+An environment's `config/` directory contains settings for various services:
+
+- `elasticsearch/`
+    - `elasticsearch.yml`
+- `nginx/`
+    - `default.conf`
+    - `develop.conf`
+    - `server.conf`
+- `php-fpm/`
+    - `docker-php-ext-xdebug.ini` — this is equivalent to `php.ini`, and is where you should put settings that would be found in a file named `php.ini`, such as `max_execution_time`, `memory_limit`, `xdebug.max_nesting_level`, `post_max_size`, `upload_max_filesize`, and similar.
+    - `wp-cli.develop.yml`
+    - `wp-cli.local.yml`
+
+After making changes to files in `config/` or to `docker-compose.yml`, you must recreate the containers. Instructions for doing so can be found on this page under [Restart an environment](#restart-an-environment)
+
 ## Restart an Environment
 
 `10updocker restart <hostname>` will restart all services associated with a preexisting environment.
 
 A special hostname `all` is available that will restart all environments as well as the global services.
+
+Restarting with `10updocker restart` does not apply configuration changes. If you've made changes to an environment's `docker-compose.yml` or the files in `/config` directory, you will need to stop the environment (but not global services) and then run [`docker-compose up`](https://docs.docker.com/compose/reference/up/) to recreate the containers:
+
+0. Navigate to the root directory of the install you want to make changes to.
+1. Make your changes to the configuration files.
+2. Run `10updocker stop all` to stop all environments, including the global services.
+3. Run `10updocker start` to get this install and the global services running.
+4. Run `10updocker stop` to stop this install but not the global services.
+5. Run [`docker-compose up`](https://docs.docker.com/compose/reference/up/) to recreate and start this install's docker containers. Wait for it to finish starting; this can be determined by watching the console output. Don't load the site in a browser. If there hasn't been anything new on the console for at least 10 seconds, you can proceed to the next step.
+6. Kill the newly-started docker process with the `Control-C` keyboard command, or your system's equivalent instruction.
+7. Run `10updocker restart` to restart the container.
+8. The settings specified should now apply.
 
 ## Upgrade an Environment
 


### PR DESCRIPTION
### Description of the Change

Answers the following questions:
- Where's `php.ini`?
- Why didn't my edits to `docker-compose.yml` or `docker-php-ext-xdebug.ini` take effect?
- How do I make changes work?

This is in response to a series of comments, from 10up and external users, who didn't know these things. By writing them down, hopefully we'll improve people's ability to use 10up's WP Local Docker

It also appears to address https://github.com/10up/wp-local-docker-docs/issues/42

### Alternate Designs

- I considered putting the configuration instructions at the bottom of `Environments.md`, but putting them between "Create" and "Restart" seemed to make more sense, given the typical workflow of an engineer creating an environment for the first time.
- I considered leaving off [the full instructions that I had written for rebuilding a container](https://github.com/10up/wp-local-docker-v2/issues/86#issuecomment-853155266), but to do would have left users without an example workflow.

### Benefits

- Improved ability for users to configure environments
- Fewer support requests

### Possible Drawbacks

- Slightly messier
- The internal link to another headline on the page might break

### Verification Process

- I'm relying on GitHub's Markdown Editor's syntax checker
- I don't have a copy of this site building anywhere.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [x] I have updated the documentation accordingly.
- [ ] ~I have added tests to cover my change.~
- [ ] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/wp-local-docker-docs/issues/42

### Changelog Entry

(omitted because this documentation project does not have a changelog)